### PR TITLE
Add Nickname frame support and enhance Import Deck features

### DIFF
--- a/creator/index.html
+++ b/creator/index.html
@@ -794,6 +794,44 @@
 							<h5 class='padding margin-bottom input-description'>When on: if a code is entered below it is applied to every card, otherwise each card's own set is used (the rarity from each card is always kept). Turn it off to add no set symbol at all.</h5>
 							<input id='importSetSymbolCodeDeck' class='input margin-bottom' type='text' placeholder="Set symbol code (e.g. 'neo', 'mh3')">
 						</div>
+						<div class='readable-background margin-bottom padding'>
+							<h5 class='collapsible collapsed padding input-description' onclick='toggleCollapse(event);'>Collector info</h5>
+							<div class='padding'>
+								<label class='checkbox-container input margin-bottom'>Add collector info
+									<input id='deckCollectorToggle' type='checkbox'>
+									<span class='checkmark'></span>
+								</label>
+								<h5 class='margin-top margin-bottom input-description'>Uses the new (post-ONE) collector info style. Empty fields are left blank, like the Collector Info tab.</h5>
+								<label class='checkbox-container input margin-bottom'>Auto progressive card number
+									<input id='deckCollectorAutoNumber' type='checkbox' checked>
+									<span class='checkmark'></span>
+								</label>
+								<input id='deckCollectorNumber' class='input margin-bottom' type='text' placeholder='Card number (used when auto is off)'>
+								<label class='checkbox-container input margin-bottom'>Rarity from each card
+									<input id='deckCollectorRarityFromCard' type='checkbox' checked>
+									<span class='checkmark'></span>
+								</label>
+								<input id='deckCollectorRarity' class='input margin-bottom' type='text' placeholder='Rarity (used when off, e.g. C / U / R / M)'>
+								<label class='checkbox-container input margin-bottom'>Artist from each card
+									<input id='deckCollectorArtistFromCard' type='checkbox' checked>
+									<span class='checkmark'></span>
+								</label>
+								<h5 class='margin-top margin-bottom input-description'>Applied once to every card:</h5>
+								<div class='padding input-grid'>
+									<input id='deckCollectorSet' class='input' type='text' placeholder='Set (e.g. NEO)'>
+									<input id='deckCollectorLanguage' class='input' type='text' placeholder='Language (e.g. EN)'>
+									<input id='deckCollectorArtist' class='input' type='text' placeholder='Artist (when off above)'>
+								</div>
+								<div class='padding input-grid'>
+									<input id='deckCollectorYear' class='input' type='number' placeholder='Year'>
+									<input id='deckCollectorNote' class='input' type='text' placeholder='Note'>
+								</div>
+								<div class='padding input-grid'>
+									<input id='deckCollectorNoteExtra1' class='input' type='text' placeholder='Extra Note 1'>
+									<input id='deckCollectorNoteExtra2' class='input' type='text' placeholder='Extra Note 2'>
+								</div>
+							</div>
+						</div>
 						<div class='readable-background padding margin-bottom'>
 							<h5 class='padding margin-bottom input-description'>Generate and download all cards in the decklist</h5>
 							<button id='generate-deck-button' class='input margin-bottom' onclick='generateDeck();'>Generate & Download Deck</button>

--- a/creator/index.html
+++ b/creator/index.html
@@ -742,12 +742,14 @@
 						<div class='readable-background margin-bottom padding'>
 							<h5 class='padding margin-bottom input-description'>Paste your decklist below</h5>
 							<h5 class='padding margin-bottom input-description'>Format: {numberOfCopies} {cardName} (e.g., "1 Negate" or "15 Plains")</h5>
-							<textarea id='deck-list-input' class='input margin-bottom' placeholder='1 Negate&#10;1 Pilgrim&apos;s Eye&#10;15 Plains&#10;1 Port Town' rows='15'></textarea>
+							<h5 class='padding margin-bottom input-description'>Nickname frames: append the nickname in square brackets after the card name, e.g. "1 Llanowar Elves [Elf Bestie]". The card name still goes in the Title field (used for the Scryfall lookup); the bracketed text becomes the Nickname. Cards with no brackets fall back to using the card name as the nickname.</h5>
+							<textarea id='deck-list-input' class='input margin-bottom' placeholder='1 Negate&#10;1 Llanowar Elves [Elf Bestie]&#10;15 Plains&#10;1 Questing Beast [The Beast]' rows='15'></textarea>
 						</div>
 						<div class='readable-background margin-bottom padding'>
 							<h5 class='padding margin-bottom input-description'>Or upload a single image or ZIP file of card images</h5>
 							<h5 class='padding margin-bottom input-description'>For single images: filename should be the card name (e.g., "Forest.jpg", "Spider-Man 2099.png")</h5>
 							<h5 class='padding margin-bottom input-description'>For ZIP files: multiple copies can be indicated with _(number) suffix (e.g., "Plains_(2).png")</h5>
+							<h5 class='padding margin-bottom input-description'>Nickname frames: add the nickname in square brackets after the card name in the filename, e.g. "Llanowar Elves [Elf Bestie].png" or "Llanowar Elves [Elf Bestie]_(2).png". The card name is used for the Scryfall lookup and goes in the Title field; the bracketed text becomes the Nickname.</h5>
 							<div class='padding drop-area'>
 					            <h5 class='margin-bottom padding input-description'>Drag and drop single image (PNG/JPG) or ZIP file, or click to select</h5>
 					            <input id='deck-zip-input' type='file' accept='.zip,.png,.jpg,.jpeg' placeholder='Upload file' class='input' onchange='handleFileUpload(event);'>

--- a/creator/index.html
+++ b/creator/index.html
@@ -780,6 +780,8 @@
 								<option value="BloomburrowBorderlessColored">Bloomburrow Borderless (Colored)</option>
 								<option value="M15Nickname">Nickname Frames</option>
 								<option value="IkoNicknameShort">Nickname Frames (Extra Short)</option>
+								<option value="PromoRegular-1">Borderless Frames</option>
+								<option value="IkoShort">Borderless Frames (Extra Short)</option>
 							</select>
 							<label class='checkbox-container input margin-bottom'>Import flavor text
 								<input id='importFlavorTextDeck' type='checkbox' checked>
@@ -853,6 +855,8 @@
 							<option value="BloomburrowBorderlessColored">Bloomburrow Borderless (Colored)</option>
 							<option value="M15Nickname">Nickname Frames</option>
 							<option value="IkoNicknameShort">Nickname Frames (Extra Short)</option>
+							<option value="PromoRegular-1">Borderless Frames</option>
+							<option value="IkoShort">Borderless Frames (Extra Short)</option>
 						</select>
 
 						

--- a/creator/index.html
+++ b/creator/index.html
@@ -785,6 +785,12 @@
 								<input id='importFlavorTextDeck' type='checkbox' checked>
 								<span class='checkmark'></span>
 							</label>
+							<label class='checkbox-container input margin-bottom'>Use custom set symbol
+								<input id='importSetSymbolToggleDeck' type='checkbox'>
+								<span class='checkmark'></span>
+							</label>
+							<h5 class='padding margin-bottom input-description'>Set symbol code applied to every card (the rarity from each card is kept). Leave the toggle off to use each card's own set.</h5>
+							<input id='importSetSymbolCodeDeck' class='input margin-bottom' type='text' placeholder="Set symbol code (e.g. 'neo', 'mh3')">
 						</div>
 						<div class='readable-background padding margin-bottom'>
 							<h5 class='padding margin-bottom input-description'>Generate and download all cards in the decklist</h5>

--- a/creator/index.html
+++ b/creator/index.html
@@ -785,11 +785,11 @@
 								<input id='importFlavorTextDeck' type='checkbox' checked>
 								<span class='checkmark'></span>
 							</label>
-							<label class='checkbox-container input margin-bottom'>Use custom set symbol
-								<input id='importSetSymbolToggleDeck' type='checkbox'>
+							<label class='checkbox-container input margin-bottom'>Insert set symbol
+								<input id='importSetSymbolToggleDeck' type='checkbox' checked>
 								<span class='checkmark'></span>
 							</label>
-							<h5 class='padding margin-bottom input-description'>Set symbol code applied to every card (the rarity from each card is kept). Leave the toggle off to use each card's own set.</h5>
+							<h5 class='padding margin-bottom input-description'>When on: if a code is entered below it is applied to every card, otherwise each card's own set is used (the rarity from each card is always kept). Turn it off to add no set symbol at all.</h5>
 							<input id='importSetSymbolCodeDeck' class='input margin-bottom' type='text' placeholder="Set symbol code (e.g. 'neo', 'mh3')">
 						</div>
 						<div class='readable-background padding margin-bottom'>

--- a/creator/index.html
+++ b/creator/index.html
@@ -776,6 +776,8 @@
 								<option value="M15Eighth">M15-Eighth</option>
 								<option value="M15EighthUB">M15-Eighth Universes Beyond</option>
 								<option value="BloomburrowBorderlessColored">Bloomburrow Borderless (Colored)</option>
+								<option value="M15Nickname">Nickname Frames</option>
+								<option value="IkoNicknameShort">Nickname Frames (Extra Short)</option>
 							</select>
 							<label class='checkbox-container input margin-bottom'>Import flavor text
 								<input id='importFlavorTextDeck' type='checkbox' checked>
@@ -841,6 +843,8 @@
 							<option value="M15Eighth">M15-Eighth</option>
 							<option value="M15EighthUB">M15-Eighth Universes Beyond</option>
 							<option value="BloomburrowBorderlessColored">Bloomburrow Borderless (Colored)</option>
+							<option value="M15Nickname">Nickname Frames</option>
+							<option value="IkoNicknameShort">Nickname Frames (Extra Short)</option>
 						</select>
 
 						

--- a/docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md
+++ b/docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md
@@ -1,0 +1,238 @@
+# Spec: supporto frame Nickname in Import Deck
+
+**Data:** 2026-06-30
+**Stato:** approvato, pronto per implementazione
+
+## Obiettivo
+
+Estendere la funzionalità **Import Deck** (lista nomi carta o ZIP di immagini → mazzo
+auto-framed) per supportare i **frame Nickname**: frame in cui un *nickname* va in cima
+alla carta nell'apposito campo `Nickname`, mentre il nome originale della carta finisce nel
+campo `Title` (spostato più in basso da quei frame).
+
+Primo supporto a due frame con **regole d'assemblaggio identiche**:
+- **Nickname Frames** → `packM15Nickname.js` (value dropdown: `M15Nickname`)
+- **Nickname Frames (Extra Short)** → `packIkoNicknameShort.js` (value dropdown: `IkoNicknameShort`)
+
+Regola d'assemblaggio (per entrambi): frame base del colore giusto + **Crown** se la carta è
+`Legendary`, **altrimenti Title** (PNG del frame, non i campi di testo) + **Power/Toughness** se
+creatura. Nome originale → campo `TITLE`, nickname → campo `NICKNAME`.
+
+L'architettura deve essere **estensibile**: aggiungere frame nickname futuri (o non-nickname)
+deve costare poco. Vedi §8.
+
+## Decisioni di design (confermate dall'utente)
+
+1. **Formato nickname unificato a parentesi quadre** `[Nickname]`, identico per decklist e nomi
+   file (caratteri validi su ogni filesystem, un solo parser). Input senza `[...]` → comportamento
+   identico a oggi (retrocompatibile).
+2. **Fallback quando manca il nickname** (frame nickname selezionato ma carta senza `[...]`):
+   nickname = nome della carta (in entrambi i campi Nickname e Title).
+3. **Esposizione in entrambi i dropdown**: Import Deck (`#deck-autoframe`) e autoframe singola
+   carta (`#autoFrame`), come fatto per Bloomburrow.
+
+## Contesto del codice (verificato)
+
+### Pipeline Import Deck (sia testo che ZIP)
+`parseDeckList`/`parseImageFilename` → `cards: [{name, copies, ...}]` →
+`importCardForDeck(name)` (Scryfall exact-name, popola `card.text.title/type/rules/mana/pt` via
+`changeCardIndex`) → `autoFrame()` (costruisce `card.frames`) → render canvas → ZIP.
+
+### File e funzioni rilevanti
+- `js/creator-23.js`
+  - `parseDeckList(deckListText)` — **~5072**. Regex `^(\d+)\s+(.+)$` → `{name, copies}`.
+  - `generateDeck()` — **~5100**. Loop testo; chiama `importCardForDeck` poi `autoFrame()` (~5196).
+  - `importCardForDeck(cardName)` — **~5463**. Scryfall exact-name; popola i campi testo.
+  - `sanitizeFilename(name)` — **~5588**.
+  - `handleSingleImageUpload`/`handleZipUpload` — **~5617 / ~5651**. Usano `parseImageFilename`.
+  - `zipCardImages` (global) — **~5594**. Oggi: `{ [cardName]: [imageUrl, ...] }`.
+  - `parseImageFilename(filename)` — **~5749**. Toglie ext, suffisso copia `_(\d+)$`, `_`→spazi.
+  - `generateDeckFromZip()` — **~5762**. Costruisce `cards` da `zipCardImages`; chiama
+    `importCardForDeck` poi `autoFrame()` (~5861).
+- `js/autoFrame.js`
+  - `getFrameTypeConfig(frameType)` — **~37**. Registry dei frame standard.
+  - `autoFrameUnified(...)` — **~1598**. Costruttore generico (crown/PT centralizzati). **Non tocca
+    il layout testo.**
+  - `autoFrame()` — **~1639**. Color detection + routing. Ramo standard (`getFrameTypeConfig` +
+    `autoFrameUnified`) e ramo speciale Bloomburrow (`autoBloomburrowFrame`, ~1743).
+  - `autoBloomburrowFrame(...)` — **~1752**. Pattern di riferimento: filtra frame, ricostruisce
+    `card.frames`, `addFrame([], item)` per ciascuno, reverse. **Da imitare.**
+  - `cardFrameProperties(colors, mana, type, power)` — in `creator-23.js` (~695). Ritorna
+    `{frame, pinline, pinlineRight, pt}` (lettere colore).
+- `js/creator-23.js`
+  - `addFrame(additionalMasks = [], loadingFrame = false)` — **~882**. Quando `loadingFrame` è un
+    oggetto frame, lo aggiunge (carica image+masks, `card.frames.unshift`). Usato così da
+    `autoBloomburrowFrame`: `addFrame([], frameObj)`.
+  - `loadTextOptions(textObject, replace=true)` — **~1196**. `replace=true` sostituisce
+    interamente `card.text` (azzera i valori).
+- `creator/index.html`
+  - `#deck-autoframe` (~759) e `#autoFrame` (~812): i due `<select>`. Gruppo "Custom frames".
+
+### Struttura dei frame nickname (verificata su entrambi i pack)
+Gli element name sono **identici** nei due pack (un solo handler li serve entrambi):
+`'<Colore> Frame'`, `'<Colore> Crown'`, `'<Colore> Title'`, `'<Colore> Power/Toughness'`,
+con `<Colore>` ∈ {White, Blue, Black, Red, Green, Multicolored, Artifact, Land, Colorless}.
+Note: il PT esiste come `Colorless Power/Toughness` (non "Land"); esistono varianti `Artifact (Alt)`.
+
+Layout testo del pack (definito in `loadFrameVersion.onclick`):
+- `nickname`: `{x:0.0854, y:0.0522, ...}` (in alto, grande, `belerenb`)
+- `title`: `{x:0.14, y:0.1129, ..., align:'center'}` (spostato giù, piccolo, `mplantini`)
+- più `mana`, `type`, `rules`, `pt`.
+
+**Punto critico:** nessun path di `autoFrame()` carica il layout testo. I frame standard
+funzionano perché il default M15 combacia. I frame nickname **no**: senza caricare il layout
+nickname, il campo `nickname` non esiste e il `title` resta in alto. Quindi l'handler nickname
+DEVE applicare il layout del pack e poi ripopolare i valori testo.
+
+## Implementazione
+
+### 1. Parsing input (`js/creator-23.js`)
+
+Helper condiviso (mettere vicino a `parseDeckList`/`parseImageFilename`):
+```js
+function splitNickname(rawName) {
+  const m = rawName.match(/^(.*?)\s*\[(.+)\]\s*$/);
+  return m ? { name: m[1].trim(), nickname: m[2].trim() }
+           : { name: rawName.trim(), nickname: '' };
+}
+```
+
+**`parseDeckList`**: dopo aver ottenuto `cardName` dal regex esistente, applicare `splitNickname`
+e fare push di `{ name, nickname, copies }`.
+
+**`parseImageFilename`**: cambiare il valore di ritorno a `{ name, nickname }`. Ordine:
+1. togli estensione, 2. togli suffisso copia `_(\d+)$`, 3. `splitNickname`, 4. `_`→spazi su
+**sia** `name` **sia** `nickname`, 5. trim.
+Esempio: `Sol Ring [Il Mio Anello]_(2).png` → `{name:'Sol Ring', nickname:'Il Mio Anello'}`.
+
+**`zipCardImages`** (`handleZipUpload`, `handleSingleImageUpload`, `clearUploadedFiles`,
+`generateDeckFromZip`): la struttura passa da `{ [name]: [url,...] }` a
+`{ [name]: { nickname, urls: [url,...] } }`. Il nickname è lo stesso per tutte le copie. In
+`generateDeckFromZip` propagare `nickname` in ogni `cardEntry`. Aggiornare ogni punto che oggi
+fa `zipCardImages[cardName].push(url)` e che itera `Object.entries(zipCardImages)`.
+**Attenzione** a `handleSingleImageUpload`: oggi mette `cardName` (stringa) in `singleImageUpload`;
+aggiornare per portare anche il nickname.
+
+### 2. Threading del nickname fino ad `autoFrame()`
+
+`autoFrame()` non riceve dati per-carta oltre a `card.text`. Introdurre una variabile globale,
+settata dai due loop di generazione **subito prima** di chiamare `autoFrame()` e resettata dopo:
+```js
+window.deckImportNickname = cardEntry.nickname || '';
+// ... autoFrame() ...
+window.deckImportNickname = '';
+```
+Da fare in **entrambi** `generateDeck` (~5196) e `generateDeckFromZip` (~5861).
+Nel flusso singola-carta (`setAutoFrame`) la variabile resta `''` → fallback = nome.
+
+### 3. Registry + handler (`js/autoFrame.js`)
+
+**Registry** (estensibile — qui si aggiungono i frame nickname futuri):
+```js
+const NICKNAME_FRAME_CONFIG = {
+  'M15Nickname':      { pack: 'M15Nickname' },
+  'IkoNicknameShort': { pack: 'IkoNicknameShort' }
+};
+```
+
+**Routing** in `autoFrame()` — nuovo ramo `else if` accanto a quello di Bloomburrow (~1743):
+```js
+} else if (NICKNAME_FRAME_CONFIG[frame]) {
+  autoNicknameFrame(
+    NICKNAME_FRAME_CONFIG[frame], colors,
+    card.text.mana.text, card.text.type.text, card.text.pt.text,
+    window.deckImportNickname || ''
+  );
+  if (autoFramePack != frame) {
+    loadScript('/js/frames/pack' + frame + '.js');
+    autoFramePack = frame;
+  }
+}
+```
+
+**`autoNicknameFrame(config, colors, mana_cost, type_line, power, nickname)`** — passi:
+1. **Assicurarsi che il pack sia caricato** (loadScript + attesa) così `availableFrames` e il
+   `loadFrameVersion` del pack sono disponibili. (Vedi §6 sul timing — preferibile precaricare.)
+2. **Snapshot** dei valori testo correnti: `title, type, rules, mana, pt` (settati da
+   `importCardForDeck`).
+3. **Applicare il layout nickname** eseguendo il `loadFrameVersion.onclick` del pack (stesso
+   codice del flusso manuale: crea il campo `nickname`, sposta `title`, imposta art/symbol/
+   watermark bounds e `card.version`). Questo **azzera** i valori testo (per quello serve lo
+   snapshot). È `async` → da `await`.
+4. **Ripristinare** i valori snapshot nei rispettivi campi (title = nome originale, type, rules,
+   mana, pt). Solo le chiavi presenti.
+5. **Settare il nickname**: `card.text.nickname.text = nickname || card.text.title.text`
+   (fallback = nome carta).
+6. **Assemblare i frame** imitando `autoBloomburrowFrame`: ricostruire `card.frames`
+   (preservando eventuali extension/holo come fa Bloomburrow), selezionare gli element per nome
+   da `availableFrames`, clonarli (`JSON.parse(JSON.stringify(el))`) e aggiungerli con
+   `addFrame([], clone)`, con reverse finale come Bloomburrow. Ordine layer (dal basso):
+   - base: `'<Colore> Frame'`
+   - se `type_line.toLowerCase().includes('legendary')`: `'<Colore> Crown'`, **altrimenti**
+     `'<Colore> Title'`
+   - se la carta ha P/T (`power` non vuoto): `'<Colore> Power/Toughness'`
+   Risolvere `<Colore>` riusando `cardFrameProperties(colors, mana_cost, type_line, power)`
+   (lettera `frame`) e mappando: W→White, U→Blue, B→Black, R→Red, G→Green, M→Multicolored,
+   A→Artifact, L→Land, C→Colorless. Per il PT mappare L→Colorless (non esiste "Land PT").
+   Se un element name non esiste in `availableFrames`, saltarlo senza errori.
+
+### 4. Dropdown (`creator/index.html`)
+
+Aggiungere in **entrambi** i `<select>` (`#deck-autoframe` ~759 e `#autoFrame` ~812), nel gruppo
+"Custom frames" (vicino a Bloomburrow):
+```html
+<option value="M15Nickname">Nickname Frames</option>
+<option value="IkoNicknameShort">Nickname Frames (Extra Short)</option>
+```
+Il `value` combacia con la chiave del registry e con `pack<Value>.js` (così `loadScript` risolve).
+
+## 5. Retrocompatibilità
+
+- Decklist/file senza `[...]` → parse identico a oggi.
+- Frame non-nickname → invariati.
+- `parseImageFilename` cambia tipo di ritorno (`{name, nickname}`): aggiornare **tutti** i
+  chiamanti (cercare gli usi in `creator-23.js`).
+
+## 6. Rischio: timing async
+
+I loop usano `setTimeout` fissi dopo `autoFrame()` (~1000ms). L'handler nickname aggiunge
+loadScript (rete) + `loadFrameVersion` + caricamento immagini element. Al **primo** uso il pack
+potrebbe non essere pronto entro il timeout.
+**Mitigazione:** precaricare il pack **una volta prima del loop** in `generateDeck` /
+`generateDeckFromZip` quando `selectedFrameStyle` è un frame nickname (loadScript + breve attesa),
+così durante il framing per-carta è già disponibile. Mantenere le attese esistenti. Non rendere
+`autoFrame()` awaitabile se non necessario (eviterebbe regressioni sugli altri rami).
+
+## 7. Verifica (manuale, in browser)
+
+1. Decklist mista:
+   ```
+   1 Llanowar Elves [Eletta degli Elfi]
+   1 Sol Ring
+   1 Questing Beast [La Bestia]
+   ```
+   con frame "Nickname Frames" selezionato → la prima ha nickname in alto e nome sotto; Sol Ring
+   ha nickname = "Sol Ring" (fallback); Questing Beast (Legendary) usa la **Crown** non il Title.
+2. Stessa decklist con "Nickname Frames (Extra Short)".
+3. ZIP con file `Llanowar Elves [Eletta degli Elfi].png` e `Sol Ring.png` → stesso risultato.
+4. Creatura → presenza del riquadro P/T; non-creatura → assente.
+5. Frame standard (es. Regular, Bloomburrow) → comportamento invariato.
+6. Carta con nome senza brackets su frame standard → invariato.
+
+## 8. Estensione futura (note per chi aggiungerà altri frame)
+
+Aggiungere un nuovo frame nickname con le **stesse** regole (Crown/Title/PT, element name
+standard):
+1. Voce in `NICKNAME_FRAME_CONFIG` (`'ValueDropdown': { pack: 'ValueDropdown' }`).
+2. Due `<option value="ValueDropdown">…</option>` nei due select.
+3. Verificare che `pack<ValueDropdown>.js` esponga gli element name
+   `'<Colore> Frame/Crown/Title/Power/Toughness'` e definisca i campi testo `nickname`+`title` nel
+   suo `loadFrameVersion`.
+
+Frame con regole diverse (inner crown, holo stamp, split pinline multicolor, art bounds
+particolari) → arricchire il `config` con flag/funzioni dedicate, sulla falsariga di
+`getFrameTypeConfig` (`supportsCrown`, `makeFrameFunction`, ecc.) e ramificare in
+`autoNicknameFrame`.
+
+Per i frame **senza** nickname si continua a usare il path standard (`getFrameTypeConfig` +
+`autoFrameUnified`) o un handler dedicato come Bloomburrow.

--- a/docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md
+++ b/docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md
@@ -236,3 +236,32 @@ particolari) → arricchire il `config` con flag/funzioni dedicate, sulla falsar
 
 Per i frame **senza** nickname si continua a usare il path standard (`getFrameTypeConfig` +
 `autoFrameUnified`) o un handler dedicato come Bloomburrow.
+
+## 9. Insidie scoperte in fase di implementazione (post-spec)
+
+- **Maschere degli element del pack** (`drawFrames`): le `masks` di un element nel pack sono la
+  lista delle maschere *selezionabili* (l'utente ne sceglie una). `drawFrames` però applica
+  **tutte** le maschere dell'array con `globalCompositeOperation = 'source-in'` ⇒ **intersezione**:
+  clonando l'element con la sua lista completa (es. base frame `[Pinline, Type, Rules, Border]`)
+  il layer diventa invisibile. Quando si assembla per programma, **azzerare `masks`** sui cloni
+  (i PNG sono immagini standalone già sagomate, da mostrare intere ai loro `bounds`), come fa
+  `makeBloomburrowFrameByLetter`.
+- **Z-order dei layer**: `card.frames[0]` è disegnato per ultimo (in cima); `drawFrames` fa
+  `card.frames.slice().reverse()`. Quindi nell'ordine di push il **base frame va per ultimo**
+  (sta in fondo) e Crown/Title + P/T vanno **prima** (in cima). Altrimenti il bordo inferiore
+  opaco del base frame copre il riquadro P/T.
+- **Re-render del testo**: il testo principale è disegnato da `drawText`, schedulato (debounce
+  500ms) da `drawTextBuffer`. `loadTextOptions` (quindi il `loadFrameVersion` del pack) lo
+  schedula; le modifiche sincrone fatte dopo (valori, width) vengono incluse quando il timer
+  scatta. Se si modificano i campi testo fuori da quel path (es. Bloomburrow non chiama
+  `loadTextOptions`), chiamare esplicitamente `drawTextBuffer()`.
+- **Overlap testo (mana / set symbol)**: NON è specifico dei frame nickname — le bounds di
+  `title`/`type` (width `0.8292`) e `mana` (`0.9292`) sono **identiche** al frame "Regular", e il
+  set symbol è sempre disegnato in `drawCard` **sopra** il testo. Per i frame con assemblaggio
+  automatico via import è stato aggiunto `clampImportTextWidths(topNameKey)` (in `autoFrame.js`):
+  **solo durante Import Deck** (`deckGenerationState.isGenerating`) restringe il box del nome in
+  alto e del type per far scattare lo shrink-to-fit (il testo non viene mai tagliato), in modo
+  content-aware (riserva spazio solo se mana/set symbol presenti) e clampando da una width di
+  default memorizzata (`_importFullWidth`) per non accumulare tra carte. L'editing manuale resta
+  invariato. Va richiamato da ogni handler di assemblaggio import (nickname → `'nickname'`,
+  Bloomburrow → `'title'`).

--- a/docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md
+++ b/docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md
@@ -221,18 +221,22 @@ così durante il framing per-carta è già disponibile. Mantenere le attese esis
 
 ## 8. Estensione futura (note per chi aggiungerà altri frame)
 
-Aggiungere un nuovo frame nickname con le **stesse** regole (Crown/Title/PT, element name
-standard):
-1. Voce in `NICKNAME_FRAME_CONFIG` (`'ValueDropdown': { pack: 'ValueDropdown' }`).
-2. Due `<option value="ValueDropdown">…</option>` nei due select.
-3. Verificare che `pack<ValueDropdown>.js` esponga gli element name
-   `'<Colore> Frame/Crown/Title/Power/Toughness'` e definisca i campi testo `nickname`+`title` nel
-   suo `loadFrameVersion`.
+> NOTA (aggiornamento): il registry è stato rinominato `IMPORT_FRAME_CONFIG` e l'handler
+> generalizzato in `autoElementFrame(config, ...)` con flag `nickname` / `crown` / `titleElement`,
+> per coprire anche i frame **senza** nickname (es. Borderless). Vedi §10.
+
+Aggiungere un nuovo frame assemblato per element name:
+1. Voce in `IMPORT_FRAME_CONFIG`:
+   `'ValueDropdown': { pack: 'ValueDropdown', nickname: <bool>, crown: <bool>, titleElement: <bool> }`.
+2. Due `<option value="ValueDropdown">…</option>` nei due select (`#deck-autoframe` e `#autoFrame`).
+3. Verificare che `pack<ValueDropdown>.js` esponga gli element name `'<Colore> Frame'`,
+   `'<Colore> Power/Toughness'` e, se applicabile, `'<Colore> Crown'`/`'<Colore> Title'`, e definisca
+   i campi testo nel suo `loadFrameVersion` (`nickname`+`title` per i frame nickname, solo `title`
+   altrimenti).
 
 Frame con regole diverse (inner crown, holo stamp, split pinline multicolor, art bounds
-particolari) → arricchire il `config` con flag/funzioni dedicate, sulla falsariga di
-`getFrameTypeConfig` (`supportsCrown`, `makeFrameFunction`, ecc.) e ramificare in
-`autoNicknameFrame`.
+particolari) → arricchire il `config` con altri flag/funzioni dedicate, sulla falsariga di
+`getFrameTypeConfig`, e ramificare in `autoElementFrame`.
 
 Per i frame **senza** nickname si continua a usare il path standard (`getFrameTypeConfig` +
 `autoFrameUnified`) o un handler dedicato come Bloomburrow.
@@ -265,3 +269,21 @@ Per i frame **senza** nickname si continua a usare il path standard (`getFrameTy
   default memorizzata (`_importFullWidth`) per non accumulare tra carte. L'editing manuale resta
   invariato. Va richiamato da ogni handler di assemblaggio import (nickname → `'nickname'`,
   Bloomburrow → `'title'`).
+
+## 10. Generalizzazione (post-spec) — frame per element name + set symbol import
+
+- **Handler generalizzato**: `NICKNAME_FRAME_CONFIG` → **`IMPORT_FRAME_CONFIG`**, `autoNicknameFrame`
+  → **`autoElementFrame(config, ...)`** con flag `nickname` / `crown` / `titleElement`. Assembla
+  base `'<Colore> Frame'` + (`'<Colore> Crown'` se legendary e `crown`, altrimenti `'<Colore> Title'`
+  se `titleElement`) + `'<Colore> Power/Toughness'` se creatura. Imposta il campo `nickname` solo se
+  `config.nickname`; il clamp del nome usa `'nickname'` o `'title'` di conseguenza.
+- **Frame supportati**: `M15Nickname`/`IkoNicknameShort` (nickname:true, crown:true, titleElement:true);
+  `PromoRegular-1` = "Borderless Frames" e `IkoShort` = "Borderless Frames (Extra Short)" (tutti
+  false → solo base + P/T, niente nickname/crown, titolo nel campo `title` normale). I nomi nel frame
+  picker manuale vengono da `groupPromo-2.js`.
+- **Set symbol import** (`applyDeckSetSymbolOverride`, creator-23.js, dopo `importCardForDeck` nei tre
+  generatori): toggle `#importSetSymbolToggleDeck` "Insert set symbol" (default ON) + campo
+  `#importSetSymbolCodeDeck`. OFF → nessun simbolo (codice svuotato + `setSymbol.src = blank.src`);
+  ON+codice → quel codice ovunque; ON+vuoto → set proprio di ogni carta (`scryfallCard[idx].set`).
+  Necessario perché `changeCardIndex` ha l'assegnazione del codice **commentata** (~riga 4484) ma
+  chiama comunque `fetchSetSymbol()` → default `'cmd'` con campo vuoto.

--- a/docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md
+++ b/docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md
@@ -287,3 +287,10 @@ Per i frame **senza** nickname si continua a usare il path standard (`getFrameTy
   ON+codice → quel codice ovunque; ON+vuoto → set proprio di ogni carta (`scryfallCard[idx].set`).
   Necessario perché `changeCardIndex` ha l'assegnazione del codice **commentata** (~riga 4484) ma
   chiama comunque `fetchSetSymbol()` → default `'cmd'` con campo vuoto.
+- **Collector info import** (`applyDeckCollectorInfo(entryNumber)`, creator-23.js, dopo
+  `importCardForDeck` nei tre generatori): pannello collassabile "Collector info" (`#deckCollector*`).
+  Toggle ON → forza lo stile new (post-ONE) + show, poi riempie i campi `#info-*`: numero
+  (progressivo auto zero-pad, o valore inserito), rarità (prima lettera della carta, o inserita),
+  artista (della carta, o inserito), e set/language/year/note uniformi. Campi vuoti lasciati vuoti.
+  Il render riusa la pipeline `bottomInfoEdited` (i `#info-*` → placeholder `{elemidinfo-*}`).
+  Collassabile via `class='collapsible collapsed'` + `toggleCollapse` (js/main-1.js).

--- a/js/autoFrame.js
+++ b/js/autoFrame.js
@@ -23,6 +23,18 @@
 
 
 // ============================================================================
+// NICKNAME FRAME REGISTRY
+// ============================================================================
+// Extendable registry of frame types that use the nickname layout (separate
+// Nickname and Title text fields, assembled by autoNicknameFrame).
+// To add a new nickname frame: add a key matching the dropdown value and
+// pack<Value>.js filename. See spec §8 for details.
+const NICKNAME_FRAME_CONFIG = {
+	'M15Nickname':      { pack: 'M15Nickname' },
+	'IkoNicknameShort': { pack: 'IkoNicknameShort' }
+};
+
+// ============================================================================
 // SECTION 1: FRAME TYPE CONFIGURATION
 // ============================================================================
 // Defines the high-level configuration for each frame type, including which
@@ -1746,7 +1758,112 @@ function autoFrame() {
 			loadScript('/js/frames/pack' + frame + '.js');
 			autoFramePack = frame;
 		}
+	} else if (NICKNAME_FRAME_CONFIG[frame]) {
+		autoNicknameFrame(
+			NICKNAME_FRAME_CONFIG[frame], colors,
+			card.text.mana.text, card.text.type.text, card.text.pt.text,
+			window.deckImportNickname || ''
+		);
+		if (autoFramePack != frame) {
+			loadScript('/js/frames/pack' + frame + '.js');
+			autoFramePack = frame;
+		}
 	}
+}
+
+// Assembles a nickname-style frame (one with separate Nickname + Title text fields).
+// Imitates autoBloomburrowFrame: snapshot text, apply pack layout, restore text, set nickname,
+// build frame layers from availableFrames by element name.
+async function autoNicknameFrame(config, colors, mana_cost, type_line, power, nickname) {
+	// Map color letter → full color name used in element names
+	const colorNameMap = {
+		'W': 'White', 'U': 'Blue', 'B': 'Black', 'R': 'Red', 'G': 'Green',
+		'M': 'Multicolored', 'A': 'Artifact', 'L': 'Land', 'C': 'Colorless',
+		'V': 'Artifact'  // Vehicle → use Artifact frame
+	};
+	// For PT the pack has no "Land" variant; use Colorless instead
+	const ptColorNameMap = Object.assign({}, colorNameMap, { 'L': 'Colorless' });
+
+	// Determine color letter using cardFrameProperties
+	var properties = cardFrameProperties(colors, mana_cost, type_line, power);
+	var colorLetter = properties.frame ? properties.frame.toUpperCase() : 'A';
+	var colorName = colorNameMap[colorLetter] || 'Artifact';
+	var ptColorName = ptColorNameMap[colorLetter] || 'Colorless';
+
+	// Snapshot text values set by importCardForDeck before the layout is overwritten
+	var snapshot = {};
+	if (card.text) {
+		Object.keys(card.text).forEach(key => {
+			snapshot[key] = card.text[key].text;
+		});
+	}
+
+	// Apply the pack's nickname text layout (creates the nickname field, repositions title, etc.)
+	// The pack must be loaded before this is called (preloaded in generateDeck/generateDeckFromZip).
+	var loadBtn = document.querySelector('#loadFrameVersion');
+	if (loadBtn && typeof loadBtn.onclick === 'function') {
+		await loadBtn.onclick();
+	}
+
+	// Restore snapshotted text values (loadTextOptions preserves existing keys automatically,
+	// but an explicit restore ensures correctness even if the field names changed)
+	if (card.text) {
+		Object.keys(snapshot).forEach(key => {
+			if (card.text[key]) {
+				card.text[key].text = snapshot[key];
+			}
+		});
+	}
+
+	// Set the nickname field: use provided nickname or fall back to the card's own title
+	if (card.text && card.text.nickname) {
+		card.text.nickname.text = nickname || (card.text.title ? card.text.title.text : '');
+	}
+
+	// Preserve extension/holo frames (same pattern as autoBloomburrowFrame)
+	var preservedFrames = card.frames.filter(frame =>
+		frame.name.includes('Extension') ||
+		frame.name.includes('Gray Holo Stamp') ||
+		frame.name.includes('Gold Holo Stamp')
+	);
+
+	card.frames = [];
+	document.querySelector('#frame-list').innerHTML = null;
+
+	// Helper: find a frame element by name in availableFrames and clone it
+	function findFrameElement(name) {
+		if (!availableFrames) return null;
+		var el = availableFrames.find(f => f.name === name);
+		return el ? JSON.parse(JSON.stringify(el)) : null;
+	}
+
+	var newFrames = [...preservedFrames];
+
+	// Layer order (bottom to top before reverse):
+	// 1. Base frame
+	var baseEl = findFrameElement(colorName + ' Frame');
+	if (baseEl) newFrames.push(baseEl);
+
+	// 2. Crown (if Legendary) or Title frame element
+	var isLegendary = type_line.toLowerCase().includes('legendary');
+	if (isLegendary) {
+		var crownEl = findFrameElement(colorName + ' Crown');
+		if (crownEl) newFrames.push(crownEl);
+	} else {
+		var titleEl = findFrameElement(colorName + ' Title');
+		if (titleEl) newFrames.push(titleEl);
+	}
+
+	// 3. Power/Toughness (only if card has P/T)
+	if (power) {
+		var ptEl = findFrameElement(ptColorName + ' Power/Toughness');
+		if (ptEl) newFrames.push(ptEl);
+	}
+
+	card.frames = newFrames;
+	card.frames.reverse();
+	await card.frames.forEach(item => addFrame([], item));
+	card.frames.reverse();
 }
 
 async function autoBloomburrowFrame(colors, mana_cost, type_line, power) {

--- a/js/autoFrame.js
+++ b/js/autoFrame.js
@@ -1771,6 +1771,61 @@ function autoFrame() {
 	}
 }
 
+// Import-only polish: long auto-imported card names / type lines would otherwise overlap the
+// mana cost or run under the set symbol (this is stock frame behaviour — the text boxes are as
+// wide as on the "Regular" frame). Here we narrow the relevant text BOXES so writeText's
+// shrink-to-fit makes the text smaller (it is never clipped) instead of overlapping its neighbour.
+// Content-aware: space is reserved only when a mana cost / set symbol is actually present, and
+// sized to how much room they actually take. Widths are clamped from a stored default so repeated
+// imports don't compound. Applies only during Import Deck generation (manual editing is untouched).
+function clampImportTextWidths(topNameKey) {
+	if (typeof deckGenerationState === 'undefined' || !deckGenerationState.isGenerating) { return; }
+	if (!card.text) { return; }
+	var aspect = card.height / card.width; // px height / px width (~1.4); converts a height-sized square to width units
+
+	// Top name (nickname or title) vs. mana cost (mana is right-aligned to mana.x + mana.width)
+	var nameField = card.text[topNameKey];
+	var mana = card.text.mana;
+	if (nameField) {
+		if (nameField._importFullWidth == null) { nameField._importFullWidth = nameField.width; }
+		var fullW = nameField._importFullWidth;
+		var manaSymbols = (mana && mana.text) ? (mana.text.match(/{[^}]+}/g) || []) : [];
+		if (manaSymbols.length > 0) {
+			var symbolW = (mana.size || 0.043) * aspect; // one pip ≈ a square of height mana.size
+			var manaRight = (mana.x || 0) + (mana.width || 1);
+			var reserve = manaSymbols.length * symbolW + 0.012; // pips + a small gap
+			var avail = (manaRight - reserve) - (nameField.x || 0);
+			nameField.width = Math.max(0.2, Math.min(fullW, avail));
+		} else {
+			nameField.width = fullW; // no mana cost → full width available
+		}
+	}
+
+	// Type line vs. set symbol (optional). Set symbol ≈ a square fit to setSymbolBounds.height.
+	var typeField = card.text.type;
+	var ssb = card.setSymbolBounds;
+	var setCodeEl = document.querySelector('#set-symbol-code');
+	if (typeField) {
+		if (typeField._importFullWidth == null) { typeField._importFullWidth = typeField.width; }
+		var fullTW = typeField._importFullWidth;
+		if (ssb && setCodeEl && setCodeEl.value) {
+			var symW = (ssb.height || 0.04) * aspect;
+			var ssLeft;
+			if (ssb.horizontal === 'right') { ssLeft = (ssb.x || 1) - symW; }
+			else if (ssb.horizontal === 'center') { ssLeft = (ssb.x || 1) - symW / 2; }
+			else { ssLeft = (ssb.x || 1); }
+			var availT = ssLeft - (typeField.x || 0) - 0.008;
+			typeField.width = Math.max(0.2, Math.min(fullTW, availT));
+		} else {
+			typeField.width = fullTW; // no set symbol → full width available
+		}
+	}
+
+	// Re-render the text with the adjusted widths (debounced). Needed for the Bloomburrow path,
+	// whose earlier scheduled render may have already fired before these width changes.
+	if (typeof drawTextBuffer === 'function') { drawTextBuffer(); }
+}
+
 // Assembles a nickname-style frame (one with separate Nickname + Title text fields).
 // Imitates autoBloomburrowFrame: snapshot text, apply pack layout, restore text, set nickname,
 // build frame layers from availableFrames by element name.
@@ -1819,6 +1874,9 @@ async function autoNicknameFrame(config, colors, mana_cost, type_line, power, ni
 	if (card.text && card.text.nickname) {
 		card.text.nickname.text = nickname || (card.text.title ? card.text.title.text : '');
 	}
+
+	// Import-only: keep the nickname clear of the mana cost and the type line clear of the set symbol
+	clampImportTextWidths('nickname');
 
 	// Preserve extension/holo frames (same pattern as autoBloomburrowFrame)
 	var preservedFrames = card.frames.filter(frame =>
@@ -1905,6 +1963,9 @@ async function autoBloomburrowFrame(colors, mana_cost, type_line, power) {
 	card.frames.reverse();
 	await card.frames.forEach(item => addFrame([], item));
 	card.frames.reverse();
+
+	// Import-only: keep the title clear of the mana cost and the type line clear of the set symbol
+	clampImportTextWidths('title');
 }
 
 function makeBloomburrowFrameByLetter(letter, mask = false, maskToRightHalf = false, hasPT = false) {

--- a/js/autoFrame.js
+++ b/js/autoFrame.js
@@ -1846,12 +1846,17 @@ async function autoNicknameFrame(config, colors, mana_cost, type_line, power, ni
 		return clone;
 	}
 
+	// Push order = z-order top→bottom (card.frames[0] is drawn last/on top), matching
+	// autoBloomburrowFrame: the base frame is pushed LAST so it sits at the bottom, and
+	// the Crown/Title and Power/Toughness layers sit ON TOP of it (otherwise the base
+	// frame's opaque bottom border would hide the P/T box).
 	var newFrames = [...preservedFrames];
 
-	// Layer order (bottom to top before reverse):
-	// 1. Base frame
-	var baseEl = findFrameElement(colorName + ' Frame');
-	if (baseEl) newFrames.push(baseEl);
+	// 1. Power/Toughness (topmost; only if card has P/T)
+	if (power) {
+		var ptEl = findFrameElement(ptColorName + ' Power/Toughness');
+		if (ptEl) newFrames.push(ptEl);
+	}
 
 	// 2. Crown (if Legendary) or Title frame element
 	var isLegendary = type_line.toLowerCase().includes('legendary');
@@ -1863,11 +1868,9 @@ async function autoNicknameFrame(config, colors, mana_cost, type_line, power, ni
 		if (titleEl) newFrames.push(titleEl);
 	}
 
-	// 3. Power/Toughness (only if card has P/T)
-	if (power) {
-		var ptEl = findFrameElement(ptColorName + ' Power/Toughness');
-		if (ptEl) newFrames.push(ptEl);
-	}
+	// 3. Base frame (bottommost)
+	var baseEl = findFrameElement(colorName + ' Frame');
+	if (baseEl) newFrames.push(baseEl);
 
 	card.frames = newFrames;
 	card.frames.reverse();

--- a/js/autoFrame.js
+++ b/js/autoFrame.js
@@ -23,15 +23,19 @@
 
 
 // ============================================================================
-// NICKNAME FRAME REGISTRY
+// ELEMENT-NAMED FRAME REGISTRY (Import Deck)
 // ============================================================================
-// Extendable registry of frame types that use the nickname layout (separate
-// Nickname and Title text fields, assembled by autoNicknameFrame).
-// To add a new nickname frame: add a key matching the dropdown value and
-// pack<Value>.js filename. See spec §8 for details.
-const NICKNAME_FRAME_CONFIG = {
-	'M15Nickname':      { pack: 'M15Nickname' },
-	'IkoNicknameShort': { pack: 'IkoNicknameShort' }
+// Extendable registry of frame types assembled by element name (autoElementFrame).
+// Key = dropdown value = pack<Value>.js filename. Flags:
+//   nickname     – pack has a separate Nickname text field
+//   crown        – pack has a '<Color> Crown' element for Legendary cards
+//   titleElement – pack has a '<Color> Title' element for non-Legendary cards
+// See spec §8 for how to add more.
+const IMPORT_FRAME_CONFIG = {
+	'M15Nickname':      { pack: 'M15Nickname',      nickname: true,  crown: true,  titleElement: true  },
+	'IkoNicknameShort': { pack: 'IkoNicknameShort', nickname: true,  crown: true,  titleElement: true  },
+	'PromoRegular-1':   { pack: 'PromoRegular-1',   nickname: false, crown: false, titleElement: false },
+	'IkoShort':         { pack: 'IkoShort',         nickname: false, crown: false, titleElement: false }
 };
 
 // ============================================================================
@@ -1758,9 +1762,9 @@ function autoFrame() {
 			loadScript('/js/frames/pack' + frame + '.js');
 			autoFramePack = frame;
 		}
-	} else if (NICKNAME_FRAME_CONFIG[frame]) {
-		autoNicknameFrame(
-			NICKNAME_FRAME_CONFIG[frame], colors,
+	} else if (IMPORT_FRAME_CONFIG[frame]) {
+		autoElementFrame(
+			IMPORT_FRAME_CONFIG[frame], colors,
 			card.text.mana.text, card.text.type.text, card.text.pt.text,
 			window.deckImportNickname || ''
 		);
@@ -1833,10 +1837,14 @@ function clampImportTextWidths(topNameKey) {
 	if (typeof drawTextBuffer === 'function') { drawTextBuffer(); }
 }
 
-// Assembles a nickname-style frame (one with separate Nickname + Title text fields).
-// Imitates autoBloomburrowFrame: snapshot text, apply pack layout, restore text, set nickname,
-// build frame layers from availableFrames by element name.
-async function autoNicknameFrame(config, colors, mana_cost, type_line, power, nickname) {
+// Assembles a frame whose layers are picked by element name from the pack's availableFrames.
+// Imitates autoBloomburrowFrame: snapshot text, apply the pack's text layout, restore text,
+// (optionally) set the nickname, then build base + Crown/Title + P/T layers. Config flags:
+//   nickname     – pack has a separate Nickname text field (set it; clamp the nickname box)
+//   crown        – pack has a '<Color> Crown' element to add for Legendary cards
+//   titleElement – pack has a '<Color> Title' element to add for non-Legendary cards
+// Borderless frames set all three false (just base + P/T, title in the normal title field).
+async function autoElementFrame(config, colors, mana_cost, type_line, power, nickname) {
 	// Map color letter → full color name used in element names
 	const colorNameMap = {
 		'W': 'White', 'U': 'Blue', 'B': 'Black', 'R': 'Red', 'G': 'Green',
@@ -1877,13 +1885,14 @@ async function autoNicknameFrame(config, colors, mana_cost, type_line, power, ni
 		});
 	}
 
-	// Set the nickname field: use provided nickname or fall back to the card's own title
-	if (card.text && card.text.nickname) {
+	// Set the nickname field (nickname frames only): provided nickname or fall back to the title
+	if (config.nickname && card.text && card.text.nickname) {
 		card.text.nickname.text = nickname || (card.text.title ? card.text.title.text : '');
 	}
 
-	// Import-only: keep the nickname clear of the mana cost and the type line clear of the set symbol
-	clampImportTextWidths('nickname');
+	// Import-only: keep the top name clear of the mana cost and the type line clear of the set
+	// symbol. The big top name is the nickname on nickname frames, otherwise the title.
+	clampImportTextWidths(config.nickname ? 'nickname' : 'title');
 
 	// Preserve extension/holo frames (same pattern as autoBloomburrowFrame)
 	var preservedFrames = card.frames.filter(frame =>
@@ -1923,12 +1932,12 @@ async function autoNicknameFrame(config, colors, mana_cost, type_line, power, ni
 		if (ptEl) newFrames.push(ptEl);
 	}
 
-	// 2. Crown (if Legendary) or Title frame element
+	// 2. Crown (Legendary) or Title element, when the pack provides them
 	var isLegendary = type_line.toLowerCase().includes('legendary');
-	if (isLegendary) {
+	if (config.crown && isLegendary) {
 		var crownEl = findFrameElement(colorName + ' Crown');
 		if (crownEl) newFrames.push(crownEl);
-	} else {
+	} else if (config.titleElement) {
 		var titleEl = findFrameElement(colorName + ' Title');
 		if (titleEl) newFrames.push(titleEl);
 	}

--- a/js/autoFrame.js
+++ b/js/autoFrame.js
@@ -1801,7 +1801,10 @@ function clampImportTextWidths(topNameKey) {
 		}
 	}
 
-	// Type line vs. set symbol (optional). Set symbol ≈ a square fit to setSymbolBounds.height.
+	// Type line vs. set symbol (optional). The symbol is scaled to fit setSymbolBounds and can
+	// occupy up to the full bounds WIDTH, so reserve the whole bounds width (the symbol's left
+	// edge can reach setSymbolBounds.x - width) to guarantee the type clears it regardless of the
+	// symbol's aspect ratio — a height-based square estimate under-reserved for wider symbols.
 	var typeField = card.text.type;
 	var ssb = card.setSymbolBounds;
 	var setCodeEl = document.querySelector('#set-symbol-code');
@@ -1809,10 +1812,10 @@ function clampImportTextWidths(topNameKey) {
 		if (typeField._importFullWidth == null) { typeField._importFullWidth = typeField.width; }
 		var fullTW = typeField._importFullWidth;
 		if (ssb && setCodeEl && setCodeEl.value) {
-			var symW = (ssb.height || 0.04) * aspect;
+			var reserveW = ssb.width || ((ssb.height || 0.04) * aspect);
 			var ssLeft;
-			if (ssb.horizontal === 'right') { ssLeft = (ssb.x || 1) - symW; }
-			else if (ssb.horizontal === 'center') { ssLeft = (ssb.x || 1) - symW / 2; }
+			if (ssb.horizontal === 'right') { ssLeft = (ssb.x || 1) - reserveW; }
+			else if (ssb.horizontal === 'center') { ssLeft = (ssb.x || 1) - reserveW / 2; }
 			else { ssLeft = (ssb.x || 1); }
 			var availT = ssLeft - (typeField.x || 0) - 0.008;
 			typeField.width = Math.max(0.2, Math.min(fullTW, availT));

--- a/js/autoFrame.js
+++ b/js/autoFrame.js
@@ -1980,6 +1980,14 @@ async function autoBloomburrowFrame(colors, mana_cost, type_line, power) {
 	await card.frames.forEach(item => addFrame([], item));
 	card.frames.reverse();
 
+	// Bloomburrow frames darken the art behind the text, so the text must be white. This handler
+	// doesn't apply the pack's text layout (which sets white), so without this the M15-default
+	// black is used and the text is unreadable.
+	['title', 'type', 'rules', 'pt'].forEach(function(key) {
+		if (card.text && card.text[key]) { card.text[key].color = 'white'; }
+	});
+	if (typeof drawTextBuffer === 'function') { drawTextBuffer(); }
+
 	// Import-only: keep the title clear of the mana cost and the type line clear of the set symbol
 	clampImportTextWidths('title');
 }

--- a/js/autoFrame.js
+++ b/js/autoFrame.js
@@ -1830,11 +1830,20 @@ async function autoNicknameFrame(config, colors, mana_cost, type_line, power, ni
 	card.frames = [];
 	document.querySelector('#frame-list').innerHTML = null;
 
-	// Helper: find a frame element by name in availableFrames and clone it
+	// Helper: find a frame element by name in availableFrames and clone it.
+	// The pack's `masks` array on each element is the list of SELECTABLE masks
+	// (meant for the user to pick one); drawFrames() applies every mask in the
+	// array via 'source-in', i.e. as an intersection, which for the base frame's
+	// [Pinline, Type, Rules, Border] is ~empty and masks the whole layer out.
+	// These nickname PNGs are standalone, already-shaped images shown whole at
+	// their bounds, so we drop the masks entirely (same as autoBloomburrowFrame).
 	function findFrameElement(name) {
 		if (!availableFrames) return null;
 		var el = availableFrames.find(f => f.name === name);
-		return el ? JSON.parse(JSON.stringify(el)) : null;
+		if (!el) return null;
+		var clone = JSON.parse(JSON.stringify(el));
+		clone.masks = [];
+		return clone;
 	}
 
 	var newFrames = [...preservedFrames];

--- a/js/autoFrame.js
+++ b/js/autoFrame.js
@@ -1808,10 +1808,14 @@ function clampImportTextWidths(topNameKey) {
 	var typeField = card.text.type;
 	var ssb = card.setSymbolBounds;
 	var setCodeEl = document.querySelector('#set-symbol-code');
+	// A set symbol is shown if a code is entered OR a (non-blank) symbol image is loaded — the
+	// latter catches CardConjurer's default symbol, which renders even with an empty code field.
+	var hasSetSymbol = (setCodeEl && setCodeEl.value) ||
+		(card.setSymbolSource && card.setSymbolSource.indexOf('/img/blank.png') === -1);
 	if (typeField) {
 		if (typeField._importFullWidth == null) { typeField._importFullWidth = typeField.width; }
 		var fullTW = typeField._importFullWidth;
-		if (ssb && setCodeEl && setCodeEl.value) {
+		if (ssb && hasSetSymbol) {
 			var reserveW = ssb.width || ((ssb.height || 0.04) * aspect);
 			var ssLeft;
 			if (ssb.horizontal === 'right') { ssLeft = (ssb.x || 1) - reserveW; }

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -5172,7 +5172,7 @@ async function generateDeck() {
 	}
 
 	// Preload nickname frame pack before the loop to avoid async-timing issues (spec §6)
-	if (typeof NICKNAME_FRAME_CONFIG !== 'undefined' && NICKNAME_FRAME_CONFIG[selectedFrameStyle]) {
+	if (typeof IMPORT_FRAME_CONFIG !== 'undefined' && IMPORT_FRAME_CONFIG[selectedFrameStyle]) {
 		loadScript('/js/frames/pack' + selectedFrameStyle + '.js');
 		await new Promise(resolve => setTimeout(resolve, 800));
 	}
@@ -5335,7 +5335,7 @@ async function generateSingleCard() {
 	}
 
 	// Preload nickname frame pack before the loop to avoid async-timing issues (spec §6)
-	if (typeof NICKNAME_FRAME_CONFIG !== 'undefined' && NICKNAME_FRAME_CONFIG[selectedFrameStyle]) {
+	if (typeof IMPORT_FRAME_CONFIG !== 'undefined' && IMPORT_FRAME_CONFIG[selectedFrameStyle]) {
 		loadScript('/js/frames/pack' + selectedFrameStyle + '.js');
 		await new Promise(resolve => setTimeout(resolve, 800));
 	}
@@ -5895,7 +5895,7 @@ async function generateDeckFromZip() {
 	}
 
 	// Preload nickname frame pack before the loop to avoid async-timing issues (spec §6)
-	if (typeof NICKNAME_FRAME_CONFIG !== 'undefined' && NICKNAME_FRAME_CONFIG[selectedFrameStyle]) {
+	if (typeof IMPORT_FRAME_CONFIG !== 'undefined' && IMPORT_FRAME_CONFIG[selectedFrameStyle]) {
 		loadScript('/js/frames/pack' + selectedFrameStyle + '.js');
 		await new Promise(resolve => setTimeout(resolve, 800));
 	}

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -5199,6 +5199,7 @@ async function generateDeck() {
 			try {
 				// Import the card from Scryfall
 				await importCardForDeck(cardEntry.name);
+				applyDeckSetSymbolOverride();
 
 				progressText.textContent = `Loading: ${cardEntry.name}...`;
 
@@ -5356,6 +5357,7 @@ async function generateSingleCard() {
 
 		// Import the card from Scryfall
 		await importCardForDeck(cardName);
+		applyDeckSetSymbolOverride();
 
 		progressText.textContent = `Loading: ${cardName}...`;
 		progressBar.value = 40;
@@ -5484,6 +5486,18 @@ function fetchScryfallCardByExactName(cardName) {
 			reject(new Error(`Scryfall API request failed: ${error.message}`));
 		}
 	});
+}
+
+// Import Deck: when the "Use custom set symbol" toggle is on, override the set symbol code for
+// every generated card with the user-provided code, keeping each card's own rarity (already set
+// by changeCardIndex). Call this right after importCardForDeck, before the card is rendered.
+function applyDeckSetSymbolOverride() {
+	const toggle = document.querySelector('#importSetSymbolToggleDeck');
+	const codeEl = document.querySelector('#importSetSymbolCodeDeck');
+	if (toggle && toggle.checked && codeEl && codeEl.value.trim()) {
+		document.querySelector('#set-symbol-code').value = codeEl.value.trim();
+		fetchSetSymbol(); // re-fetches with the custom code + the per-card rarity
+	}
 }
 
 function importCardForDeck(cardName) {
@@ -5885,6 +5899,7 @@ async function generateDeckFromZip() {
 			try {
 				// Import the card from Scryfall
 				await importCardForDeck(cardEntry.name);
+				applyDeckSetSymbolOverride();
 
 				progressText.textContent = `Loading: ${cardEntry.name}...`;
 

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -5200,6 +5200,7 @@ async function generateDeck() {
 				// Import the card from Scryfall
 				await importCardForDeck(cardEntry.name);
 				applyDeckSetSymbolOverride();
+				await applyDeckCollectorInfo(cards.indexOf(cardEntry) + 1);
 
 				progressText.textContent = `Loading: ${cardEntry.name}...`;
 
@@ -5358,6 +5359,7 @@ async function generateSingleCard() {
 		// Import the card from Scryfall
 		await importCardForDeck(cardName);
 		applyDeckSetSymbolOverride();
+		await applyDeckCollectorInfo(1);
 
 		progressText.textContent = `Loading: ${cardName}...`;
 		progressBar.value = 40;
@@ -5524,6 +5526,60 @@ function applyDeckSetSymbolOverride() {
 		document.querySelector('#set-symbol-code').value = code;
 		fetchSetSymbol(); // re-fetches with this code + the per-card rarity
 	}
+}
+
+// Import Deck collector info. Call right after importCardForDeck (await it), before rendering.
+// When the "Add collector info" toggle is on, forces the new (post-ONE) style + shows collector
+// info, then fills the #info-* fields used by the render: card number (auto-progressive or the
+// entered value), rarity (from each card or the entered value), artist (from each card or the
+// entered value), and the uniform set/language/year/notes. Empty fields are left blank.
+// entryNumber is the 1-based position used for the auto-progressive card number.
+async function applyDeckCollectorInfo(entryNumber) {
+	const enable = document.querySelector('#deckCollectorToggle');
+	if (!enable || !enable.checked) { return; }
+
+	const card0 = (() => {
+		try {
+			const idx = document.querySelector('#import-index').value || 0;
+			return (typeof scryfallCard !== 'undefined' && scryfallCard) ? scryfallCard[idx] : null;
+		} catch (e) { return null; }
+	})();
+	const val = id => { const el = document.querySelector(id); return el ? el.value.trim() : ''; };
+
+	// Force the new (post-ONE) collector style and make collector info visible.
+	document.querySelector('#enableNewCollectorStyle').checked = true;
+	document.querySelector('#enableCollectorInfo').checked = true;
+	localStorage.setItem('enableNewCollectorStyle', 'true');
+	localStorage.setItem('enableCollectorInfo', 'true');
+
+	// Card number: auto-progressive (zero-padded) or the entered value.
+	const autoNum = document.querySelector('#deckCollectorAutoNumber');
+	document.querySelector('#info-number').value =
+		(autoNum && autoNum.checked) ? String(entryNumber).padStart(3, '0') : val('#deckCollectorNumber');
+
+	// Rarity: from the card (first letter, uppercase) or the entered value.
+	const rarFromCard = document.querySelector('#deckCollectorRarityFromCard');
+	document.querySelector('#info-rarity').value =
+		(rarFromCard && rarFromCard.checked) ? (card0 && card0.rarity ? card0.rarity.charAt(0).toUpperCase() : '')
+		                                     : val('#deckCollectorRarity');
+
+	// Artist: from the card or the entered value.
+	const artFromCard = document.querySelector('#deckCollectorArtistFromCard');
+	document.querySelector('#info-artist').value =
+		(artFromCard && artFromCard.checked) ? (card0 && card0.artist ? card0.artist : '')
+		                                     : val('#deckCollectorArtist');
+
+	// Uniform fields (left blank when empty).
+	document.querySelector('#info-set').value = val('#deckCollectorSet');
+	document.querySelector('#info-language').value = val('#deckCollectorLanguage');
+	document.querySelector('#info-year').value = val('#deckCollectorYear');
+	document.querySelector('#info-note').value = val('#deckCollectorNote');
+	document.querySelector('#info-note-extra-1').value = val('#deckCollectorNoteExtra1');
+	document.querySelector('#info-note-extra-2').value = val('#deckCollectorNoteExtra2');
+
+	// Rebuild the bottom-info layout for the new style, then render with the values above.
+	await setBottomInfoStyle();
+	bottomInfoEdited();
 }
 
 function importCardForDeck(cardName) {
@@ -5926,6 +5982,7 @@ async function generateDeckFromZip() {
 				// Import the card from Scryfall
 				await importCardForDeck(cardEntry.name);
 				applyDeckSetSymbolOverride();
+				await applyDeckCollectorInfo(cards.indexOf(cardEntry) + 1);
 
 				progressText.textContent = `Loading: ${cardEntry.name}...`;
 

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -5488,15 +5488,30 @@ function fetchScryfallCardByExactName(cardName) {
 	});
 }
 
-// Import Deck: when the "Use custom set symbol" toggle is on, override the set symbol code for
-// every generated card with the user-provided code, keeping each card's own rarity (already set
-// by changeCardIndex). Call this right after importCardForDeck, before the card is rendered.
+// Import Deck set symbol handling. Call right after importCardForDeck, before the card is rendered.
+// changeCardIndex leaves #set-symbol-code unset on import (its code assignment is commented out)
+// yet still calls fetchSetSymbol(), which falls back to CardConjurer's 'cmd' default symbol — that
+// default then shows on every card and, since the code field stays empty, the type-line clamp
+// can't detect it. We fix both: when the "Use custom set symbol" toggle is on, apply the entered
+// code to every card; otherwise apply each card's OWN set code (from Scryfall). Either way the
+// code field is populated (no 'cmd' default) and the per-card rarity set by changeCardIndex kept.
 function applyDeckSetSymbolOverride() {
 	const toggle = document.querySelector('#importSetSymbolToggleDeck');
 	const codeEl = document.querySelector('#importSetSymbolCodeDeck');
+	let code = '';
 	if (toggle && toggle.checked && codeEl && codeEl.value.trim()) {
-		document.querySelector('#set-symbol-code').value = codeEl.value.trim();
-		fetchSetSymbol(); // re-fetches with the custom code + the per-card rarity
+		code = codeEl.value.trim(); // explicit custom code for every card
+	} else if (!document.querySelector('#lockSetSymbolCode').checked) {
+		// Use the imported card's own set code instead of the 'cmd' default.
+		try {
+			const idx = document.querySelector('#import-index').value || 0;
+			const c = (typeof scryfallCard !== 'undefined' && scryfallCard) ? scryfallCard[idx] : null;
+			if (c && c.set) { code = c.set; }
+		} catch (e) { /* leave code empty */ }
+	}
+	if (code) {
+		document.querySelector('#set-symbol-code').value = code;
+		fetchSetSymbol(); // re-fetches with this code + the per-card rarity
 	}
 }
 

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -5489,18 +5489,29 @@ function fetchScryfallCardByExactName(cardName) {
 }
 
 // Import Deck set symbol handling. Call right after importCardForDeck, before the card is rendered.
-// changeCardIndex leaves #set-symbol-code unset on import (its code assignment is commented out)
-// yet still calls fetchSetSymbol(), which falls back to CardConjurer's 'cmd' default symbol — that
-// default then shows on every card and, since the code field stays empty, the type-line clamp
-// can't detect it. We fix both: when the "Use custom set symbol" toggle is on, apply the entered
-// code to every card; otherwise apply each card's OWN set code (from Scryfall). Either way the
-// code field is populated (no 'cmd' default) and the per-card rarity set by changeCardIndex kept.
+// Driven by the "Insert set symbol" toggle:
+//   - OFF: no set symbol at all (blank it out).
+//   - ON + code entered: that code on every card.
+//   - ON + no code: each card's OWN Scryfall set code.
+// This also avoids CardConjurer's 'cmd' default: changeCardIndex leaves #set-symbol-code unset on
+// import (its code assignment is commented out) yet still calls fetchSetSymbol(), which falls back
+// to 'cmd' — so without this the wrong symbol shows and the empty code field hides it from the
+// type-line clamp. The per-card rarity set by changeCardIndex is always kept.
 function applyDeckSetSymbolOverride() {
-	const toggle = document.querySelector('#importSetSymbolToggleDeck');
+	const insert = document.querySelector('#importSetSymbolToggleDeck');
 	const codeEl = document.querySelector('#importSetSymbolCodeDeck');
+
+	// Toggle off → no set symbol: clear the code and blank the symbol image.
+	if (!insert || !insert.checked) {
+		document.querySelector('#set-symbol-code').value = '';
+		setSymbol.src = blank.src;
+		card.setSymbolSource = blank.src;
+		return;
+	}
+
 	let code = '';
-	if (toggle && toggle.checked && codeEl && codeEl.value.trim()) {
-		code = codeEl.value.trim(); // explicit custom code for every card
+	if (codeEl && codeEl.value.trim()) {
+		code = codeEl.value.trim(); // explicit code for every card
 	} else if (!document.querySelector('#lockSetSymbolCode').checked) {
 		// Use the imported card's own set code instead of the 'cmd' default.
 		try {

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -5069,6 +5069,15 @@ const CANVAS_RENDER_TIMEOUT_MS = 1000; // Time to wait for canvas rendering to c
 const ART_LOAD_TIMEOUT_MS = 3000; // Time to wait for art image to load
 const ART_LOAD_POLL_INTERVAL_MS = 250; // Interval for polling art load status
 
+// Splits a raw card name into { name, nickname }.
+// Supports the unified [Nickname] bracket syntax: "Card Name [Nickname]" → { name, nickname }.
+// Without brackets, nickname is '' (no-op for non-nickname frames).
+function splitNickname(rawName) {
+	const m = rawName.match(/^(.*?)\s*\[(.+)\]\s*$/);
+	return m ? { name: m[1].trim(), nickname: m[2].trim() }
+	         : { name: rawName.trim(), nickname: '' };
+}
+
 function parseDeckList(deckListText) {
 	const lines = deckListText.trim().split('\n');
 	const cards = [];
@@ -5077,15 +5086,15 @@ function parseDeckList(deckListText) {
 		const trimmedLine = line.trim();
 		if (!trimmedLine) continue;
 
-		// Parse format: {numberOfCopies} {cardName}
+		// Parse format: {numberOfCopies} {cardName [optionalNickname]}
 		const match = trimmedLine.match(/^(\d+)\s+(.+)$/);
 		if (match) {
 			const copies = parseInt(match[1], 10);
-			const cardName = match[2].trim();
+			const { name, nickname } = splitNickname(match[2].trim());
 
 			// Validate number of copies
 			if (copies >= 1 && copies <= 100) {
-				cards.push({ name: cardName, copies: copies });
+				cards.push({ name, nickname, copies });
 			} else {
 				console.warn(`Invalid number of copies for card: ${line}`);
 			}
@@ -5162,6 +5171,12 @@ async function generateDeck() {
 		localStorage.setItem('autoFrame', selectedFrameStyle);
 	}
 
+	// Preload nickname frame pack before the loop to avoid async-timing issues (spec §6)
+	if (typeof NICKNAME_FRAME_CONFIG !== 'undefined' && NICKNAME_FRAME_CONFIG[selectedFrameStyle]) {
+		loadScript('/js/frames/pack' + selectedFrameStyle + '.js');
+		await new Promise(resolve => setTimeout(resolve, 800));
+	}
+
 	// Show progress UI
 	const progressDiv = document.querySelector('#deck-progress');
 	const progressText = document.querySelector('#deck-progress-text');
@@ -5193,7 +5208,9 @@ async function generateDeck() {
 				// Trigger autoframe if enabled
 				if (selectedFrameStyle !== 'false') {
 					progressText.textContent = `Framing: ${cardEntry.name}...`;
+					window.deckImportNickname = cardEntry.nickname || '';
 					autoFrame();
+					window.deckImportNickname = '';
 					// Wait for autoframe to complete
 					await new Promise(resolve => setTimeout(resolve, 1000));
 				}
@@ -5287,6 +5304,7 @@ async function generateSingleCard() {
 	}
 
 	const cardName = singleImageUpload.cardName;
+	const cardNickname = singleImageUpload.nickname || '';
 
 	// Ask user for confirmation
 	const confirmed = confirm(
@@ -5313,6 +5331,12 @@ async function generateSingleCard() {
 	if (selectedFrameStyle !== 'false') {
 		document.querySelector('#autoFrame').value = selectedFrameStyle;
 		localStorage.setItem('autoFrame', selectedFrameStyle);
+	}
+
+	// Preload nickname frame pack before the loop to avoid async-timing issues (spec §6)
+	if (typeof NICKNAME_FRAME_CONFIG !== 'undefined' && NICKNAME_FRAME_CONFIG[selectedFrameStyle]) {
+		loadScript('/js/frames/pack' + selectedFrameStyle + '.js');
+		await new Promise(resolve => setTimeout(resolve, 800));
 	}
 
 	// Show progress UI
@@ -5377,7 +5401,9 @@ async function generateSingleCard() {
 
 		// Trigger autoframe if enabled
 		if (selectedFrameStyle !== 'false') {
+			window.deckImportNickname = cardNickname;
 			autoFrame();
+			window.deckImportNickname = '';
 			// Wait for autoframe to complete - use longer timeout for complex frames
 			await new Promise(resolve => setTimeout(resolve, AUTOFRAME_TIMEOUT_MS));
 		}
@@ -5622,12 +5648,13 @@ async function handleSingleImageUpload(event) {
 		// Clear any existing uploads
 		clearUploadedFiles();
 
-		const cardName = parseImageFilename(file.name);
+		const { name: cardName, nickname: cardNickname } = parseImageFilename(file.name);
 		const imageUrl = URL.createObjectURL(file);
 
 		// Store single image upload
 		singleImageUpload = {
 			cardName: cardName,
+			nickname: cardNickname,
 			imageUrl: imageUrl,
 			fileName: file.name
 		};
@@ -5678,15 +5705,15 @@ async function handleZipUpload(event) {
 
 		// Process each image
 		for (const { fileName, zipEntry } of imageFiles) {
-			const cardName = parseImageFilename(fileName);
+			const { name: cardName, nickname: cardNickname } = parseImageFilename(fileName);
 			const blob = await zipEntry.async('blob');
 			const imageUrl = URL.createObjectURL(blob);
 
-			// Store image URL by card name
+			// Store image URL and nickname by card name
 			if (!zipCardImages[cardName]) {
-				zipCardImages[cardName] = [];
+				zipCardImages[cardName] = { nickname: cardNickname, urls: [] };
 			}
-			zipCardImages[cardName].push(imageUrl);
+			zipCardImages[cardName].urls.push(imageUrl);
 		}
 
 		notify(`Loaded ${imageFiles.length} image(s) from ZIP for ${Object.keys(zipCardImages).length} unique card(s).`, 3);
@@ -5719,7 +5746,7 @@ function clearUploadedFiles() {
 function clearZipImages() {
 	// Release object URLs to free memory
 	for (const cardName in zipCardImages) {
-		for (const url of zipCardImages[cardName]) {
+		for (const url of zipCardImages[cardName].urls) {
 			URL.revokeObjectURL(url);
 		}
 	}
@@ -5746,17 +5773,23 @@ function clearUploadedFilesUI() {
 	notify('Uploaded files cleared.', 2);
 }
 
+// Returns { name, nickname } from a filename like "Sol Ring [Anello]_(2).png".
+// Steps: strip extension → strip copy suffix → splitNickname → replace _ with spaces on both parts.
 function parseImageFilename(filename) {
 	// Remove file extension
-	let name = filename.substring(0, filename.lastIndexOf('.'));
+	let raw = filename.substring(0, filename.lastIndexOf('.'));
 
 	// Remove copy number suffix like _(2), _(3), etc.
-	name = name.replace(/_\(\d+\)$/, '');
+	raw = raw.replace(/_\(\d+\)$/, '');
 
-	// Replace underscores with spaces
-	name = name.replace(/_/g, ' ');
+	// Split into name and optional nickname using bracket syntax
+	let { name, nickname } = splitNickname(raw);
 
-	return name.trim();
+	// Replace underscores with spaces in both parts
+	name = name.replace(/_/g, ' ').trim();
+	nickname = nickname.replace(/_/g, ' ').trim();
+
+	return { name, nickname };
 }
 
 async function generateDeckFromZip() {
@@ -5773,15 +5806,17 @@ async function generateDeckFromZip() {
 	// Create card list from ZIP images
 	const cards = [];
 
-	for (const [cardName, images] of Object.entries(zipCardImages)) {
+	for (const [cardName, cardData] of Object.entries(zipCardImages)) {
+		const { nickname, urls } = cardData;
 		// Each image represents one copy
-		for (let i = 0; i < images.length; i++) {
+		for (let i = 0; i < urls.length; i++) {
 			cards.push({
 				name: cardName,
+				nickname: nickname,
 				copies: 1,
-				imageUrl: images[i],
+				imageUrl: urls[i],
 				copyNumber: i + 1,  // Track which copy this is (1-indexed)
-				totalCopies: images.length  // Total copies of this card
+				totalCopies: urls.length  // Total copies of this card
 			});
 		}
 	}
@@ -5817,6 +5852,12 @@ async function generateDeckFromZip() {
 	if (selectedFrameStyle !== 'false') {
 		document.querySelector('#autoFrame').value = selectedFrameStyle;
 		localStorage.setItem('autoFrame', selectedFrameStyle);
+	}
+
+	// Preload nickname frame pack before the loop to avoid async-timing issues (spec §6)
+	if (typeof NICKNAME_FRAME_CONFIG !== 'undefined' && NICKNAME_FRAME_CONFIG[selectedFrameStyle]) {
+		loadScript('/js/frames/pack' + selectedFrameStyle + '.js');
+		await new Promise(resolve => setTimeout(resolve, 800));
 	}
 
 	// Show progress UI
@@ -5858,7 +5899,9 @@ async function generateDeckFromZip() {
 				// Trigger autoframe if enabled
 				if (selectedFrameStyle !== 'false') {
 					progressText.textContent = `Framing: ${cardEntry.name}...`;
+					window.deckImportNickname = cardEntry.nickname || '';
 					autoFrame();
+					window.deckImportNickname = '';
 					// Wait for autoframe to complete
 					await new Promise(resolve => setTimeout(resolve, 1000));
 				}

--- a/js/frames/packM15Nickname.js
+++ b/js/frames/packM15Nickname.js
@@ -9,7 +9,7 @@ var bounds3 = {x:0.0494, y:0.0405, width:0.9014, height:0.1053};
 availableFrames = [
 	{name:'White Frame', src:'/img/frames/m15/nickname/m15NicknameFrameW.png', masks:masks},
 	{name:'Blue Frame', src:'/img/frames/m15/nickname/m15NicknameFrameU.png', masks:masks},
-	{name:'Black Frame', src:'/img/frames/m15/nickname/m\15NicknameFrameB.png', masks:masks},
+	{name:'Black Frame', src:'/img/frames/m15/nickname/m15NicknameFrameB.png', masks:masks},
 	{name:'Red Frame', src:'/img/frames/m15/nickname/m15NicknameFrameR.png', masks:masks},
 	{name:'Green Frame', src:'/img/frames/m15/nickname/m15NicknameFrameG.png', masks:masks},
 	{name:'Multicolored Frame', src:'/img/frames/m15/nickname/m15NicknameFrameM.png', masks:masks},


### PR DESCRIPTION
This pull request introduces support for Nickname Frames in the Import Deck functionality, allowing users to specify card nicknames directly in decklists and filenames, and to generate cards using new frame styles that display nicknames in a dedicated field. It also adds options for borderless frames, set symbol import, and collector info import, and generalizes the frame assembly logic to support future extensibility.

Key changes include:

**Nickname Frame and Borderless Frame Support**
- Added Nickname Frame and Borderless Frame options to both the deck autoframe and single card autoframe dropdowns in `creator/index.html`, enabling users to select these new frame styles for deck imports and single cards. [[1]](diffhunk://#diff-5df4b6f2dbe1baaa353e76b872c2de5ebe2bcdee852e0c2d3fc18a6c64dace02R781-R833) [[2]](diffhunk://#diff-5df4b6f2dbe1baaa353e76b872c2de5ebe2bcdee852e0c2d3fc18a6c64dace02R894-R897)
- Introduced a registry (`IMPORT_FRAME_CONFIG`) in `js/autoFrame.js` for element-named frames, supporting Nickname Frames (`M15Nickname`, `IkoNicknameShort`) and Borderless Frames (`PromoRegular-1`, `IkoShort`), with extensible configuration for future frame types.

**User Guidance and Input Format Updates**
- Updated instructions and placeholders in the decklist and image upload sections of `creator/index.html` to explain the new nickname syntax (`[Nickname]`) and provide examples for both decklists and filenames.

**Set Symbol and Collector Info Import**
- Added UI controls in `creator/index.html` to allow users to insert a set symbol (with override code) and to import collector info (number, rarity, artist, set, language, year, and notes) for all cards in a deck, including auto-numbering and per-card or global overrides.

**Specification and Implementation Details**
- Added a comprehensive specification in `docs/superpowers/specs/2026-06-30-nickname-import-deck-design.md` detailing the design, parsing logic, registry structure, extensibility, and edge cases for nickname and borderless frame support, as well as set symbol and collector info import.

These changes lay the groundwork for robust, extensible deck import and framing features, making it easier for users to generate custom cards with advanced frame styles and metadata.